### PR TITLE
WIP : Fix crash in boundary_loop

### DIFF
--- a/src/boolean.c
+++ b/src/boolean.c
@@ -1123,6 +1123,10 @@ static GSList * boundary_loops (GSList * boundary)
     GSList * inext = i->next;
     GtsSegment * next = inext ? inext->data : start;
     GtsVertex * v = s->v1 == next->v1 || s->v1 == next->v2 ? s->v1 : s->v2;
+    if (!v)
+    {
+      break;
+    }
 
     if (IS_SET (v, INTERIOR)) {
       GtsSegment * intprev = prev_interior (v);


### PR DESCRIPTION
  * Test vertex pointer validity before calling IS_SET(v, INTERIOR).